### PR TITLE
Add convenience initializer to SYNQueueTask

### DIFF
--- a/SYNQueue/SYNQueue/SYNQueueTask.swift
+++ b/SYNQueue/SYNQueue/SYNQueueTask.swift
@@ -91,6 +91,10 @@ public class SYNQueueTask : NSOperation {
         self.qualityOfService = qualityOfService
     }
     
+    public convenience init(queue: SYNQueue, type: String) {
+        self.init(queue: queue, taskType: type)
+    }
+    
     /**
     Initializes a SYNQueueTask from a dictionary
     

--- a/SYNQueueDemo/SYNQueueDemo/ViewController.swift
+++ b/SYNQueueDemo/SYNQueueDemo/ViewController.swift
@@ -125,13 +125,14 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
             taskType: "cellTask", dependencyStrs: [], data: [:])
         let task2 = SYNQueueTask(queue: queue, taskID: String(taskID2),
             taskType: "cellTask", dependencyStrs: [], data: [:])
+        let task3 = SYNQueueTask(queue: queue, type: "cellTask")
         
         // Make the first task dependent on the second
         task1.addDependency(task2)
         
         queue.addOperation(task1)
         queue.addOperation(task2)
-        
+        queue.addOperation(task3)
         totalTasksSeen = max(totalTasksSeen, queue.operationCount)
         updateProgress()
         


### PR DESCRIPTION
Need this for obj-c compatibility. The default parameter value init()
doesn’t work when calling from obj-c code.
